### PR TITLE
Замена облака с картинками на S3 с резервной репликацией

### DIFF
--- a/backend/src/main/java/com/yandex/practicum/devops/SausageApplication.java
+++ b/backend/src/main/java/com/yandex/practicum/devops/SausageApplication.java
@@ -19,12 +19,12 @@ public class SausageApplication {
     @Bean
     CommandLineRunner runner(ProductService productService) {
         return args -> {
-            productService.save(new Product(1L, "Сливочная", 320.00, "https://res.cloudinary.com/sugrobov/image/upload/v1623323635/repos/sausages/6.jpg"));
-            productService.save(new Product(2L, "Особая", 179.00, "https://res.cloudinary.com/sugrobov/image/upload/v1623323635/repos/sausages/5.jpg"));
-            productService.save(new Product(3L, "Молочная", 225.00, "https://res.cloudinary.com/sugrobov/image/upload/v1623323635/repos/sausages/4.jpg"));
-            productService.save(new Product(4L, "Нюренбергская", 315.00, "https://res.cloudinary.com/sugrobov/image/upload/v1623323635/repos/sausages/3.jpg"));
-            productService.save(new Product(5L, "Мюнхенская", 330.00, "https://res.cloudinary.com/sugrobov/image/upload/v1623323635/repos/sausages/2.jpg"));
-            productService.save(new Product(6L, "Американская", 189.00, "https://res.cloudinary.com/sugrobov/image/upload/v1623323635/repos/sausages/1.jpg"));
+            productService.save(new Product(1L, "Сливочная", 320.00, "https://storage.yandexcloud.net/danil-kuznetsov-bucket/images/6.jpg"));
+            productService.save(new Product(2L, "Особая", 179.00, "https://storage.yandexcloud.net/danil-kuznetsov-bucket/images/5.jpg"));
+            productService.save(new Product(3L, "Молочная", 225.00, "https://storage.yandexcloud.net/danil-kuznetsov-bucket/images/4.jpg"));
+            productService.save(new Product(4L, "Нюренбергская", 315.00, "https://storage.yandexcloud.net/danil-kuznetsov-bucket/images/3.jpg"));
+            productService.save(new Product(5L, "Мюнхенская", 330.00, "https://storage.yandexcloud.net/danil-kuznetsov-bucket/images/2.jpg"));
+            productService.save(new Product(6L, "Американская", 189.00, "https://storage.yandexcloud.net/danil-kuznetsov-bucket/images/1.jpg"));
         };
     }
 }


### PR DESCRIPTION
## Changelog

- На Яндекс.Облаке создан бакет
- Настроены права через сервисную учетку
- Поднят сервер MinIO в докере
- На MinIO залиты изображения
- Настроен rsync для репликации изображений в Яндекс Object-Storage
- В беке заменены ссылки на новый источник