### PR TITLE
Separated containers to the different microservices. Added extra reports

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,10 @@
 variables:
   VERSION: 1.0.${CI_PIPELINE_ID}
+  DOCKER_HOST: tcp://docker:2376
+  DOCKER_TLS_CERTDIR: "/certs"
+  DOCKER_TLS_VERIFY: 1
+  DOCKER_CERT_PATH: "${DOCKER_TLS_CERTDIR}/client"
+  SAST_JAVA_VERSION: 17
 
 stages:
   - module-pipelines
@@ -9,9 +14,9 @@ frontend:
   trigger:
     include:
       - "/frontend/.gitlab-ci.yml"
-    strategy: depend # depend нужен, если какой-нибудь дочерний пайплайн свалился, мы знали, что общий пайплайн тоже идёт с ошибкой
+    strategy: depend
   only:
-    changes: # как только происходит изменение в папке frontend, запускается дочерний пайплайн, который лежит в этой папке
+    changes:
       - frontend/**/*
 
 backend:
@@ -21,5 +26,15 @@ backend:
       - "/backend/.gitlab-ci.yml"
     strategy: depend
   only:
-    changes:  # как только происходит изменение в папке backend, запускается дочерний пайплайн, который лежит в этой папке
+    changes:
       - backend/**/*
+
+backend-report:
+  stage: module-pipelines
+  trigger:
+    include:
+      - "/backend-report/.gitlab-ci.yml"
+    strategy: depend
+  only:
+    changes:
+      - backend-report/**/*

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -1,10 +1,5 @@
 variables:
   BACK_ENV_NAME: production-backend
-  DOCKER_HOST: tcp://docker:2376
-  DOCKER_TLS_CERTDIR: "/certs"
-  DOCKER_TLS_VERIFY: 1
-  DOCKER_CERT_PATH: "${DOCKER_TLS_CERTDIR}/client"
-  SAST_JAVA_VERSION: 17
 
 services:
   - docker:20.10.12-dind-rootless
@@ -17,7 +12,7 @@ stages:
   - deploy
 
 include:
-  - template: Security/SAST.gitlab-ci.yml
+  remote: 'https://gitlab.com/gitlab-org/gitlab/-/raw/2851f4d5/lib/gitlab/ci/templates/Jobs/SAST.latest.gitlab-ci.yml'
 
 build-backend-code-job:
   stage: build
@@ -48,6 +43,7 @@ sonarqube-backend-sast:
       -Dsonar.projectKey=${SONAR_PROJECT_KEY_BACK}
       -Dsonar.host.url=${SONAR_URL}
       -Dsonar.login=${SAUSAGE_STORE_14_BACK_TOKEN}
+      -Dversion.application=${VERSION}
   needs:
     - build-backend-code-job
 
@@ -94,17 +90,18 @@ deploy-backend:
     - chmod 600 ~/.ssh
     - echo "${SSH_KNOWN_HOSTS}" >> ~/.ssh/known_hosts
     - chmod 644 ~/.ssh/known_hosts
-  script:
     - scp ./backend/deploy-backend.sh ${DEV_USER}@${DEV_HOST}:/home/${DEV_USER}/deploy-backend.sh
     - ssh ${DEV_USER}@${DEV_HOST} chmod +x /home/${DEV_USER}/deploy-backend.sh
+    - scp ./docker-compose.yml ${DEV_USER}@${DEV_HOST}:/home/${DEV_USER}/docker-compose.yml
+  script:
     - export VAULT_TOKEN="$(vault write -field=token auth/jwt/login role=sausage-store jwt=${CI_JOB_JWT})"
     - >
       ssh ${DEV_USER}@${DEV_HOST}
       "export "VERSION=${VERSION}";
+      export "VAULT_ADDR=${VAULT_ADDR}";
       export "SPRING_DATASOURCE_URL=${PGSQL_DATASOURCE}";
-      export "SPRING_DATASOURCE_USERNAME=$(vault kv get -field=spring.datasource.username secret/sausage-store)";
-      export "SPRING_DATASOURCE_PASSWORD=$(vault kv get -field=spring.datasource.password secret/sausage-store)";
-      export "SPRING_DATA_MONGODB_URI=$(vault kv get -field=spring.data.mongodb.uri secret/sausage-store)";
+      export "SPRING_DATASOURCE_USERNAME=${PGSQL_USER}";
+      export "SPRING_DATASOURCE_PASSWORD=${PGSQL_PASS}";
       export "BACKEND_REGISTRY_USER=${CI_REGISTRY_USER}";
       export "BACKEND_REGISTRY_PASSWORD=${CI_REGISTRY_PASSWORD}";
       export "BACKEND_REGISTRY=${CI_REGISTRY}";

--- a/backend/deploy-backend.sh
+++ b/backend/deploy-backend.sh
@@ -1,21 +1,15 @@
 #!/bin/bash
 set +e
-cat > .env <<EOF
+cat > backend.env <<EOF
+BACKEND_REGISTRY_IMAGE=${BACKEND_REGISTRY_IMAGE}
+VAULT_ADDR=${VAULT_ADDR}
 SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
 SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
 SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
-SPRING_DATA_MONGODB_URI=${SPRING_DATA_MONGODB_URI}
 SPRING_FLYWAY_ENABLED=false
 REPORT_PATH=./logs
 EOF
-docker network create -d bridge sausage_network || true
 docker login -u ${BACKEND_REGISTRY_USER} -p ${BACKEND_REGISTRY_PASSWORD} ${BACKEND_REGISTRY}
-docker pull ${BACKEND_REGISTRY_IMAGE}/sausage-backend:latest
-docker rm -f backend || true
+docker-compose --env-file backend.env pull backend
 set -e
-docker run -d \
-    --env-file .env \
-    --name backend \
-    --network=sausage_network \
-    --restart always \
-    ${BACKEND_REGISTRY_IMAGE}/sausage-backend:latest
+docker-compose --env-file backend.env up --force-recreate --remove-orphans -d backend

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,12 +24,7 @@
         <sonar.language>java</sonar.language>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     </properties>
-
     <dependencies>
-       <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-        </dependency>
        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
@@ -106,7 +101,6 @@
             <artifactId>spring-cloud-vault-config</artifactId>
         </dependency>
     </dependencies>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -118,7 +112,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
     <build>
         <plugins>
             <plugin>

--- a/frontend/.gitlab-ci.yml
+++ b/frontend/.gitlab-ci.yml
@@ -1,10 +1,5 @@
 variables:
   FRONT_ENV_NAME: production-frontend
-  DOCKER_HOST: tcp://docker:2376
-  DOCKER_TLS_CERTDIR: "/certs"
-  DOCKER_TLS_VERIFY: 1
-  DOCKER_CERT_PATH: "${DOCKER_TLS_CERTDIR}/client"
-  SAST_JAVA_VERSION: 17
 
 services:
   - docker:20.10.12-dind-rootless
@@ -18,7 +13,7 @@ stages:
   - deploy
 
 include:
-  - template: Security/SAST.gitlab-ci.yml
+  remote: 'https://gitlab.com/gitlab-org/gitlab/-/raw/2851f4d5/lib/gitlab/ci/templates/Jobs/SAST.latest.gitlab-ci.yml'
 
 build-frontend-code-job:
   stage: build
@@ -62,6 +57,7 @@ sonarqube-frontend-sast:
       -Dsonar.sources=.
       -Dsonar.host.url=${SONAR_URL}
       -Dsonar.login=${SAUSAGE_STORE_14_FRONT_TOKEN}
+      -Dsonar.projectVersion=${VERSION}
   needs:
     - build-frontend-code-job
     - test-frontend-container
@@ -110,9 +106,10 @@ deploy-frontend:
     - chmod 600 ~/.ssh
     - echo "${SSH_KNOWN_HOSTS}" >> ~/.ssh/known_hosts
     - chmod 644 ~/.ssh/known_hosts
-  script:
     - scp ./frontend/deploy-frontend.sh ${DEV_USER}@${DEV_HOST}:/home/${DEV_USER}/deploy-frontend.sh
     - ssh ${DEV_USER}@${DEV_HOST} chmod +x /home/${DEV_USER}/deploy-frontend.sh
+    - scp ./docker-compose.yml ${DEV_USER}@${DEV_HOST}:/home/${DEV_USER}/docker-compose.yml
+  script:
     - >
       ssh ${DEV_USER}@${DEV_HOST}
       "export "VERSION=${VERSION}";

--- a/frontend/deploy-frontend.sh
+++ b/frontend/deploy-frontend.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 set +e
+cat > frontend.env <<EOF
+FRONTEND_REGISTRY_IMAGE=${FRONTEND_REGISTRY_IMAGE}
+EOF
 docker login -u ${FRONTEND_REGISTRY_USER} -p ${FRONTEND_REGISTRY_PASSWORD} ${FRONTEND_REGISTRY}
-docker pull ${FRONTEND_REGISTRY_IMAGE}/sausage-frontend:latest
-docker rm -f frontend || true
+docker-compose --env-file frontend.env pull frontend
 set -e
-docker run -d \
-    --name frontend \
-    --network=sausage_network \
-    --restart always \
-    -p 80:80 \
-    ${FRONTEND_REGISTRY_IMAGE}/sausage-frontend:latest
+docker-compose up --force-recreate --remove-orphans -d frontend


### PR DESCRIPTION
- Отчеты бэкенда выделены в отдельный сервис на GO
- Отдельные запуски контейнеров заменены на docker-compose
- Повторяющиеся переменные в CI/CD вынесены в глобальные переменные (в родительский пайп)
- Убраны излишние комментарии
- Добавлен дочерний пайплайн для CI/CD сервиса отчетов
- Заменен template Gitlab SAST для всех сервисов (связанно с использованием языка GO)
- Добавлено указание версии приложения во все тесты, чтобы они отображались в SonarQube
- Возврат к использованию секретов из переменных Gitlab CI
- Из pom.xml для бэкенда убраны зависимости для mongodb